### PR TITLE
Fix charset problem and leading and trailing blank space problem

### DIFF
--- a/src/main/java/org/red5/net/websocket/WebSocketConnection.java
+++ b/src/main/java/org/red5/net/websocket/WebSocketConnection.java
@@ -116,7 +116,7 @@ public class WebSocketConnection {
 	 */
 	public void send(String data) throws UnsupportedEncodingException {
 		log.trace("send message: {}", data);
-		Packet packet = Packet.build(data.getBytes(), MessageType.TEXT);
+		Packet packet = Packet.build(data.getBytes("UTF8"), MessageType.TEXT);
 		session.write(packet);
 	}
 


### PR DESCRIPTION
First, when we send text packet, the packet must contain UTF8 string. (WebSocketConnection.java fixes)
Second, when recv text packet contains blank space at leading or trailing, it's removed at WSMessage. So I fixed it.